### PR TITLE
24/09/22 work list

### DIFF
--- a/corou-frontend/src/components/addRoutine/addRoutine2.tsx
+++ b/corou-frontend/src/components/addRoutine/addRoutine2.tsx
@@ -207,9 +207,7 @@ const AddRoutine2: React.FC<NextProps> = ({ onNext }) => {
                 }
               />
             </RoutineGradeTitle>
-            <CommonInput
-              typeValue="text"
-              placeholderValue="설명"
+            <CommonTextarea
               value={item.description}
               onChange={(e) =>
                 handleRoutineItemChange(index, "description", e.target.value)
@@ -217,6 +215,8 @@ const AddRoutine2: React.FC<NextProps> = ({ onNext }) => {
               onBlur={(e) =>
                 handleInputBlur(index, "description", e.target.value)
               }
+              placeholder="설명 (100글자 제한)"
+              maxLength={100}
             />
             <ItemSearchWrapper>
               <CommonInput
@@ -330,6 +330,18 @@ const RoutinePriceWrapper = styled.div`
 const ItemSearchWrapper = styled.div`
   width: 100%;
   position: relative;
+`;
+
+const CommonTextarea = styled.textarea`
+  width: 90% !important;
+  height: 150px !important;
+  border: 3px solid rgba(255, 164, 228, 0.5);
+  border-radius: 13px;
+  padding: 10px 10px;
+  margin-bottom: 10px;
+  font-size: 14px;
+  outline: none;
+  resize: none;
 `;
 
 const SearchResults = styled.div`

--- a/corou-frontend/src/components/detail/detailGrade.tsx
+++ b/corou-frontend/src/components/detail/detailGrade.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import ReviewPoint from "../common/reviewPoint";
 import axios from "axios";
+import styled from "styled-components";
 
 interface ItemData {
   average_rating: number;
@@ -100,9 +101,10 @@ const DetailGrade: React.FC<detailGradeData> = ({
                       <ReviewPoint />
                     </div>
                   </div>
-                  <span style={{ margin: "10px 0" }}>
-                    설명 : {routine.description}
-                  </span>
+                  <span>설명 :</span>
+                  <ItemDescription style={{ margin: "10px 0" }}>
+                    {routine.description}
+                  </ItemDescription>
                   <div className="detailItemEffect">
                     제품 효능 박스(일단 보류)
                   </div>
@@ -118,3 +120,13 @@ const DetailGrade: React.FC<detailGradeData> = ({
   );
 };
 export default DetailGrade;
+
+const ItemDescription = styled.div`
+  width: 95%;
+  margin: 0 auto 10px auto;
+  height: 100px;
+  border: 3px solid #ffa4e4;
+  border-radius: 12px;
+  padding: 5px;
+  font-size: 17px;
+`;

--- a/corou-frontend/src/components/detail/detailTitle.tsx
+++ b/corou-frontend/src/components/detail/detailTitle.tsx
@@ -15,7 +15,7 @@ const DetailTitle: React.FC<detailTitleData> = ({
       <div className="detailTitleReview">
         <img src={Star} alt="평점" />
         <span>
-          {reviewPoint} <span>({reviewMember})</span>
+          {Math.ceil(reviewPoint * 10) / 10} <span>({reviewMember})</span>
         </span>
         <span>리뷰 조회</span>
       </div>

--- a/corou-frontend/src/components/mart/buyBtn.tsx
+++ b/corou-frontend/src/components/mart/buyBtn.tsx
@@ -13,7 +13,11 @@ interface PaymentData {
   buyer_postcode: string;
 }
 
-const BuyBtn: React.FC = () => {
+interface totalPriceData {
+  totalPrice: number;
+}
+
+const BuyBtn: React.FC<totalPriceData> = ({ totalPrice }) => {
   const handlePayment = async () => {
     const { IMP } = window as any; // 타입스크립트에서 window 객체를 사용하는 방법
     const clientKey = process.env.PORTONE_CLIENT_KEY;
@@ -80,7 +84,9 @@ const BuyBtn: React.FC = () => {
             <span>총 0개</span>
           </label>
         </BuyCheck>
-        <button onClick={handlePayment}>000,000원 구매하기</button>
+        <button onClick={handlePayment}>
+          {totalPrice.toLocaleString()}원 구매하기
+        </button>
       </BuyBtnWrapper>
     </>
   );

--- a/corou-frontend/src/components/mart/martList.tsx
+++ b/corou-frontend/src/components/mart/martList.tsx
@@ -3,42 +3,107 @@ import "../../scss/mart/martList.scss";
 import notItem from "../../img/notItem.png";
 
 interface itemData {
-  id: number;
-  brand: string;
-  name: string;
-  size: number;
-  price: number;
-  itemImg: string;
+  average_rating: number;
+  brand_name: string;
+  category: string;
+  description: string;
+  item_key: number;
+  item_name: string;
+  item_price: number;
+  volume: number;
 }
 
-interface itemListData {
-  itemList: itemData[];
+interface cartItem {
+  cart_key: number;
+  item: itemData;
+  item_key: number;
+  quantity: number;
+  user_key: number;
 }
 
-const MartList: React.FC<itemListData> = ({ itemList }) => {
-  const hasItem = itemList && itemList.length > 0;
+interface cartListData {
+  cartList: cartItem[];
+  onQuantityChange: (cartKey: number, newQuantity: number) => void;
+  onCheckedItemsChange: (checkedItems: number[]) => void;
+}
+
+const MartList: React.FC<cartListData> = ({
+  cartList,
+  onQuantityChange,
+  onCheckedItemsChange,
+}) => {
+  const hasItem = cartList && cartList.length > 0;
+  const [checkedItems, setCheckedItems] = useState<number[]>([]);
+
+  const handleQuantityInputChange = (
+    cartKey: number,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const newQuantity = parseInt(e.target.value, 10);
+    if (!isNaN(newQuantity) && newQuantity >= 1) {
+      onQuantityChange(cartKey, newQuantity);
+    }
+  };
+
+  const handleCheckboxChange = (cartKey: number) => {
+    setCheckedItems((prevCheckedItems) => {
+      const updatedCheckedItems = prevCheckedItems.includes(cartKey)
+        ? prevCheckedItems.filter((key) => key !== cartKey)
+        : [...prevCheckedItems, cartKey];
+
+      onCheckedItemsChange(updatedCheckedItems);
+      return updatedCheckedItems;
+    });
+  };
 
   return (
     <>
       <div className="martListWrapper">
         {hasItem ? (
-          <div className="martItem">
-            <label>
-              <input type="checkbox" name="" id="" />
-              <div className="martItemWrapper">
-                <div className="martItemImg">
-                  <img src={itemList[0]?.itemImg} alt="itemImg" />
+          cartList.map((cartItem) => (
+            <div className="martItem" key={cartItem.cart_key}>
+              <label>
+                <input
+                  type="checkbox"
+                  name="itemCheckbox"
+                  checked={checkedItems.includes(cartItem.cart_key)}
+                  onChange={() => handleCheckboxChange(cartItem.cart_key)}
+                />
+                <div className="martItemWrapper">
+                  <div className="martItemImg">
+                    <img
+                      src={`/assets/item/${cartItem?.item_key}.jpg`}
+                      alt={cartItem?.item.item_name}
+                    />
+                  </div>
+                  <div className="martItemInfo">
+                    <span>{cartItem?.item.brand_name}</span>
+                    <span>
+                      {cartItem?.item.item_name} / {cartItem?.item.volume}ml
+                    </span>
+                    <span className="itemQuantity">
+                      수량:{" "}
+                      <input
+                        type="number"
+                        value={cartItem?.quantity}
+                        onChange={(e) =>
+                          handleQuantityInputChange(cartItem.cart_key, e)
+                        }
+                        min="1"
+                        max="100"
+                      />
+                    </span>
+                    <span>
+                      ₩{" "}
+                      {(
+                        cartItem?.item.item_price * cartItem?.quantity
+                      ).toLocaleString()}
+                    </span>
+                  </div>
                 </div>
-                <div className="martItemInfo">
-                  <span>{itemList[0]?.brand}</span>
-                  <span>
-                    {itemList[0]?.name} & {itemList[0]?.size}
-                  </span>
-                  <p>₩ {itemList[0]?.price}</p>
-                </div>
-              </div>
-            </label>
-          </div>
+              </label>
+            </div>
+          ))
         ) : (
           <div className="notItemWrapper">
             <div>

--- a/corou-frontend/src/components/mart/priceList.tsx
+++ b/corou-frontend/src/components/mart/priceList.tsx
@@ -1,14 +1,34 @@
 import "../../scss/mart/priceList.scss";
 
-interface itemPrice {
-  price: number;
+interface itemData {
+  average_rating: number;
+  brand_name: string;
+  category: string;
+  description: string;
+  item_key: number;
+  item_name: string;
+  item_price: number;
+  volume: number;
 }
 
-interface itemListData {
-  itemList: itemPrice[];
+interface cartItem {
+  cart_key: number;
+  item: itemData;
+  item_key: number;
+  quantity: number;
+  user_key: number;
 }
 
-const PriceList: React.FC<itemListData> = ({ itemList }) => {
+interface cartListData {
+  cartList: cartItem[];
+}
+
+const PriceList: React.FC<cartListData> = ({ cartList }) => {
+  const totalItemPrice = cartList.reduce(
+    (total, cartItem) => total + cartItem.item.item_price * cartItem.quantity,
+    0
+  );
+
   return (
     <>
       <div className="priceListWrapper">
@@ -16,7 +36,7 @@ const PriceList: React.FC<itemListData> = ({ itemList }) => {
           <h3>구매 금액</h3>
           <div>
             <span>상품 금액</span>
-            {/* <span>{itemList[0].price}원</span> */}
+            <span>{totalItemPrice.toLocaleString()}원</span>
           </div>
           <div>
             <span>할인 금액</span>
@@ -29,7 +49,7 @@ const PriceList: React.FC<itemListData> = ({ itemList }) => {
 
           <div>
             <span>총 구매 금액</span>
-            {/* <span>{itemList[0].price}원</span> */}
+            <span>{totalItemPrice.toLocaleString()}원</span>
           </div>
           <div>
             <span>적립혜택 예상</span>

--- a/corou-frontend/src/components/mypage/option.tsx
+++ b/corou-frontend/src/components/mypage/option.tsx
@@ -4,13 +4,28 @@ import { useNavigate } from "react-router-dom";
 
 const Option: React.FC = () => {
   const navigate = useNavigate();
+  const token = sessionStorage.getItem("authToken");
+
+  const isTokenCheck = () => {
+    return token !== null;
+  };
 
   const handleOrderList = () => {
-    navigate("/mypage/orderList");
+    if (isTokenCheck()) {
+      navigate("/mypage/orderList");
+    } else {
+      alert("로그인 후 이용해 주세요.");
+      navigate("/login");
+    }
   };
 
   const handleSetAddress = () => {
-    navigate("/mypage/setAddress");
+    if (isTokenCheck()) {
+      navigate("/mypage/setAddress");
+    } else {
+      alert("로그인 후 이용해 주세요.");
+      navigate("/login");
+    }
   };
 
   const handleNotice = () => {
@@ -36,7 +51,7 @@ const Option: React.FC = () => {
           <SettingBox name="상품 문의 내역" onClick={handleOrderList} />
           <SettingBox name="공지사항" onClick={handleNotice} />
         </SettingWrapper2>
-        <Logout onClick={handleLogout}>로그아웃</Logout>
+        {token && <Logout onClick={handleLogout}>로그아웃</Logout>}
       </OptionWrapper>
     </>
   );

--- a/corou-frontend/src/components/ranking/itemBtnBox.tsx
+++ b/corou-frontend/src/components/ranking/itemBtnBox.tsx
@@ -2,27 +2,25 @@ import { useNavigate } from "react-router-dom";
 import axios from "axios";
 
 interface itemBox {
-  itemList: number[];
+  item_key: number;
 }
 
-const DetailBtnBox: React.FC<itemBox> = ({ itemList }) => {
+const ItemBtnBox: React.FC<itemBox> = ({ item_key }) => {
   const navigate = useNavigate();
   const backPort = process.env.REACT_APP_BACKEND_PORT;
   const token = sessionStorage.getItem("authToken");
 
   const handleAddItem = async () => {
     try {
-      for (const item_key of itemList) {
-        await axios.post(
-          `${backPort}/api/order/cart`,
-          { item_key, quantity: 1 },
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          }
-        );
-      }
+      await axios.post(
+        `${backPort}/api/order/cart`,
+        { item_key: item_key, quantity: 1 },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
       console.log("장바구니에 모든 아이템 추가 성공");
       navigate("/order");
     } catch (error) {
@@ -39,4 +37,4 @@ const DetailBtnBox: React.FC<itemBox> = ({ itemList }) => {
     </>
   );
 };
-export default DetailBtnBox;
+export default ItemBtnBox;

--- a/corou-frontend/src/pages/mart.tsx
+++ b/corou-frontend/src/pages/mart.tsx
@@ -1,27 +1,94 @@
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import AboutHeader from "../components/common/aboutHeader";
 import BuyBtn from "../components/mart/buyBtn";
 import Caution from "../components/mart/caution";
 import MartList from "../components/mart/martList";
 import PriceList from "../components/mart/priceList";
 import MainFooter from "../components/common/mainFooter";
+import { useEffect, useState } from "react";
+import axios from "axios";
+
+interface itemData {
+  average_rating: number;
+  brand_name: string;
+  category: string;
+  description: string;
+  item_key: number;
+  item_name: string;
+  item_price: number;
+  volume: number;
+}
+
+interface cartItem {
+  cart_key: number;
+  item: itemData;
+  item_key: number;
+  quantity: number;
+  user_key: number;
+}
 
 const Mart: React.FC = () => {
   const navigate = useNavigate();
-  const location = useLocation();
-  const { itemList } = location.state || { itemList: [] };
+  const backPort = process.env.REACT_APP_BACKEND_PORT;
+  const token = sessionStorage.getItem("authToken");
+  const [cartList, setCartList] = useState<cartItem[]>([]);
+  const [checkedItems, setCheckedItems] = useState<number[]>([]);
+
+  useEffect(() => {
+    const fetchCartData = async () => {
+      try {
+        const response = await axios.get(`${backPort}/api/order/cart`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        console.log("장바구니 데이터", response.data);
+        setCartList(response.data);
+      } catch (error) {
+        console.error("장바구니 데이터를 불러오는 중 오류 발생", error);
+      }
+    };
+
+    fetchCartData();
+  }, [backPort, token]);
+
+  const handleQuantityChange = (cartKey: number, newQuantity: number) => {
+    setCartList((prevList) =>
+      prevList.map((cartItem) =>
+        cartItem.cart_key === cartKey
+          ? { ...cartItem, quantity: newQuantity }
+          : cartItem
+      )
+    );
+  };
+
+  const handleCheckedItemsChange = (checkedItems: number[]) => {
+    setCheckedItems(checkedItems);
+  };
 
   const handleBack = () => {
     navigate(-1);
   };
 
+  const totalPrice = cartList
+    .filter((item) => checkedItems.includes(item.cart_key))
+    .reduce((total, item) => total + item.item.item_price * item.quantity, 0);
+
   return (
     <>
       <AboutHeader Title={"장바구니"} onBack={handleBack} />
-      <MartList itemList={itemList} />
-      <PriceList itemList={itemList} />
+      <MartList
+        cartList={cartList}
+        onQuantityChange={handleQuantityChange}
+        onCheckedItemsChange={handleCheckedItemsChange}
+      />
+      <PriceList
+        cartList={cartList.filter((item) =>
+          checkedItems.includes(item.cart_key)
+        )}
+      />
       <Caution />
-      <BuyBtn />
+      <BuyBtn totalPrice={totalPrice} />
       <MainFooter />
     </>
   );

--- a/corou-frontend/src/pages/notice.tsx
+++ b/corou-frontend/src/pages/notice.tsx
@@ -1,12 +1,92 @@
 import { useNavigate } from "react-router-dom";
+import AboutHeader from "../components/common/aboutHeader";
+import MainFooter from "../components/common/mainFooter";
+import styled from "styled-components";
+import { useState } from "react";
 
 const Notice: React.FC = () => {
   const navigate = useNavigate();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleBack = () => {
+    navigate(-1);
+  };
+
+  const handleToggle = () => {
+    setIsOpen((prev) => !prev);
+  };
 
   return (
     <>
-      <div></div>
+      <AboutHeader Title="공지사항" onBack={handleBack} />
+      <NoticeWrapper>
+        <NoticeBox onClick={handleToggle} isOpen={isOpen}>
+          <NoticeDate>24-09-22</NoticeDate>
+          <NoticeTitle isOpen={isOpen}>
+            <h2>안녕하세요. corou입니다aaaaaaaaaaaaaaaa.</h2>
+          </NoticeTitle>
+          <NoticeContent isOpen={isOpen}>
+            안녕하세요 cosmetic-routine, corou 사이트를 오픈했습니다. 그동안
+            기다려 주셔서 감사합니다. 앞으로도 꾸준한 관리를 이어가겠습니다. 더
+            이상 할말은 없지만 최대한 많이 텍스트를 작성해야 테스트가 되기
+            때문에 이정도로 쓰겠습니다.
+          </NoticeContent>
+        </NoticeBox>
+      </NoticeWrapper>
+      <MainFooter />
     </>
   );
 };
 export default Notice;
+
+const NoticeWrapper = styled.div`
+  width: 100%;
+  margin-top: 30px;
+`;
+
+const NoticeBox = styled.div<{ isOpen: boolean }>`
+  width: 90%;
+  height: ${({ isOpen }) => (isOpen ? "auto" : "75px")};
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  border: 2px solid #ffa4e4;
+  border-radius: 12px;
+  overflow: hidden;
+  padding: 10px;
+  cursor: pointer;
+  transition: height 1s ease;
+`;
+
+const NoticeDate = styled.div`
+  width: 100%;
+  color: #848484;
+  font-size: 13px;
+  flex-shrink: 0;
+  margin-bottom: 5px;
+`;
+
+const NoticeTitle = styled.div<{ isOpen: boolean }>`
+  width: 100%;
+  overflow: hidden;
+
+  h2 {
+    margin: 0;
+    white-space: ${({ isOpen }) => (isOpen ? "normal" : "nowrap")};
+    text-overflow: ellipsis;
+    overflow: hidden;
+    flex-grow: 1;
+    flex-shrink: 1;
+    transition: white-space 1s ease;
+  }
+`;
+
+const NoticeContent = styled.div<{ isOpen: boolean }>`
+  width: 100%;
+  max-height: ${({ isOpen }) => (isOpen ? "1000px" : "20px")};
+  margin: 5px 0;
+  overflow: hidden;
+  white-space: ${({ isOpen }) => (isOpen ? "normal" : "nowrap")};
+  text-overflow: ellipsis;
+  transition: max-height 1s ease;
+`;

--- a/corou-frontend/src/pages/orderList.tsx
+++ b/corou-frontend/src/pages/orderList.tsx
@@ -17,6 +17,7 @@ const OrderList: React.FC = () => {
   const [orders, setOrders] = useState<orderItem[]>([]);
   const [loading, setLoading] = useState(true);
   const userKey = sessionStorage.getItem("userKey");
+  const token = sessionStorage.getItem("authToken");
 
   const handleBack = () => {
     navigate(-1);
@@ -25,7 +26,11 @@ const OrderList: React.FC = () => {
   useEffect(() => {
     const fetchOrderList = async () => {
       try {
-        const response = await axios.get(`${backPort}/api/user/1/order`);
+        const response = await axios.get(`${backPort}/api/order/itemorder`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
         setOrders(response.data);
         setLoading(false);
       } catch (err) {
@@ -81,23 +86,6 @@ const OrderList: React.FC = () => {
           ) : (
             <p>주문 내역이 없습니다.</p>
           )}
-
-          {/* 더미 */}
-          <div className="orderListBox">
-            <div className="boxTitle">
-              <span>24.09.17</span>
-              <span>주문상세</span>
-            </div>
-            <div className="boxContent">
-              <div>
-                <img src="" alt="" />
-              </div>
-              <div>
-                <span>아이템1 외 3건</span>
-                <p>₩ 00,000</p>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
       <MainFooter />

--- a/corou-frontend/src/pages/rankingDetail.tsx
+++ b/corou-frontend/src/pages/rankingDetail.tsx
@@ -1,11 +1,11 @@
 import styled from "styled-components";
-import BackHeader from "../components/common/backHeader";
-import Lotion from "../img/화장품1.jpg";
 import MainFooter from "../components/common/mainFooter";
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import axios from "axios";
 import ItemReview from "../components/common/itemReview";
+import ItemBtnBox from "../components/ranking/itemBtnBox";
+import AboutHeader from "../components/common/aboutHeader";
 
 interface ItemDetails {
   average_rating: number;
@@ -50,14 +50,17 @@ const RankingDetail: React.FC<ItemDetails> = () => {
   return (
     <>
       <RankingDetailWrapper>
-        <BackHeader onBack={handleBackPage} />
+        <AboutHeader Title="" onBack={handleBackPage} />
         <DetailItemBox>
           <ItemImg>
-            <img src={""} alt={itemDetails.item_name} />
+            <img
+              src={`/assets/item/${itemDetails.item_key}.jpg`}
+              alt={itemDetails.item_name}
+            />
           </ItemImg>
           <ItemInfo>
-            <h3>{itemDetails.item_name}</h3>
-            <p>{itemDetails.description}</p>
+            <h2>{itemDetails.item_name}</h2>
+            <ItemDescription>{itemDetails.description}</ItemDescription>
             <ItemPrice>
               <span>정가</span>
               <span>{itemDetails.item_price}원 / 50ml</span>
@@ -66,6 +69,7 @@ const RankingDetail: React.FC<ItemDetails> = () => {
           </ItemInfo>
         </DetailItemBox>
       </RankingDetailWrapper>
+      <ItemBtnBox item_key={itemDetails?.item_key} />
       <ItemReview item_key={itemDetails?.item_key} />
       <MainFooter />
     </>
@@ -85,8 +89,8 @@ const DetailItemBox = styled.div`
 `;
 
 const ItemImg = styled.div`
-  width: 80%;
-  height: auto;
+  width: 310px;
+  height: 310px;
   aspect-ratio: 1/1;
   object-fit: cover;
   margin: 0 auto;
@@ -94,8 +98,7 @@ const ItemImg = styled.div`
 
   img {
     width: 100%;
-    height: auto;
-    aspect-ratio: 1/1;
+    height: 100%;
     object-fit: cover;
   }
 `;
@@ -130,4 +133,15 @@ const ItemEffect = styled.div`
   background-color: #d9d9d9;
   border-radius: 13px;
   margin-top: 10%;
+  margin-bottom: 20px;
+`;
+
+const ItemDescription = styled.div`
+  width: 95%;
+  margin: 0 auto 10px auto;
+  height: 100px;
+  border: 3px solid #ffa4e4;
+  border-radius: 12px;
+  padding: 5px;
+  font-size: 17px;
 `;

--- a/corou-frontend/src/scss/about/filterList.scss
+++ b/corou-frontend/src/scss/about/filterList.scss
@@ -83,7 +83,10 @@
   margin-right: 20px;
 
   img {
-    width: inherit;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 9px;
   }
 }
 
@@ -149,10 +152,9 @@
   border: none;
   border-radius: 50%;
   background-color: #ffa4e4;
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
-  // margin-right: 3%;
+  position: sticky;
+  bottom: 80px;
+  margin-left: 80%;
   font-size: 65px;
   color: white;
   cursor: pointer;

--- a/corou-frontend/src/scss/mart/martList.scss
+++ b/corou-frontend/src/scss/mart/martList.scss
@@ -36,6 +36,7 @@
 }
 
 .martItemWrapper {
+  width: 100%;
   display: flex;
 
   &:hover {
@@ -104,5 +105,11 @@
     font-weight: bold;
     text-align: center;
     color: #848484;
+  }
+}
+
+.itemQuantity {
+  input {
+    width: 50%;
   }
 }


### PR DESCRIPTION
1. 장바구니 조회 구현
2. 제품 상세와 루틴 상세에서 장바구니 추가 버튼 클릭 시 아이템이 장바구니에 담기며 장바구니로 이동
3. 장바구니 내에서 해당 제품의 수량 변경 가능
4.  로그인 안되어 있을 시 주문 내역 또는 배송지 관리 누르면 -> 로그인후 사용해주세요 라는 팝업에러 뜨며 로그인 창으로 이동
5.  로그아웃 버튼은 로그인 되어있을 때만 보이도록 구현
6.  루틴 전체 조회 페이지에서 루틴 1번째 제품 이미지로 추가
7. 공지사항 - 기본 틀 구현
8.  루틴 추가 2페이지에서 설명란 textarea 변경 후 크기 증가
9. 상세 루틴, 상세 제품의 설명란 사이즈 및 UI 변경